### PR TITLE
Add multi station nearby search and transport type filtering

### DIFF
--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -72,6 +72,24 @@ def test_nearby_multi_limit_negative() -> None:
     print("NEARBY MULTI: ", stations, end="\n\n")
 
 
+def test_nearby_by_type_default_all() -> None:
+    """Test: station by coordinates and transport types (all)."""
+    lat = 48.137
+    lon = 11.575
+    station_types_none = MvgApi.nearby(lat, lon)
+    station_types_all = MvgApi.nearby(lat, lon, TransportType.all())
+    assert station_types_none["id"] == "de:09162:2"
+    assert station_types_none["id"] == station_types_all["id"]
+    print("NEARBY: ", station_types_none, end="\n\n")
+
+
+def test_nearby_by_type_() -> None:
+    """Test: station by coordinates and transport types (leading to returning non-first entry in stations)."""
+    station = MvgApi.nearby(48.137, 11.575, [TransportType.TRAM])
+    assert station["id"] == "de:09162:20"
+    print("NEARBY: ", station, end="\n\n")
+
+
 def test_filter() -> None:
     """Test: filters"""
     station = MvgApi.station("Universität, München")

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -45,6 +45,33 @@ def test_nearby() -> None:
     print("NEARBY: ", station, end="\n\n")
 
 
+def test_nearby_multi() -> None:
+    """Test: stations list by coordinates"""
+    stations = MvgApi.nearby_multi(48.1, 11.5)
+    assert stations[0]["id"] == "de:09162:1480"
+    assert isinstance(stations, list)
+    assert len(stations) > 1
+    print("NEARBY MULTI: ", stations, end="\n\n")
+
+
+def test_nearby_multi_limit() -> None:
+    """Test: stations list by coordinates with limit"""
+    stations = MvgApi.nearby_multi(48.1, 11.5, limit=3)
+    assert stations[0]["id"] == "de:09162:1480"
+    assert isinstance(stations, list)
+    assert len(stations) == 3
+    print("NEARBY MULTI: ", stations, end="\n\n")
+
+
+def test_nearby_multi_limit_negative() -> None:
+    """Test: stations list by coordinates with limit infinite"""
+    stations = MvgApi.nearby_multi(48.1, 11.5, limit=-1)
+    assert stations[0]["id"] == "de:09162:1480"
+    assert isinstance(stations, list)
+    assert len(stations) > 0
+    print("NEARBY MULTI: ", stations, end="\n\n")
+
+
 def test_filter() -> None:
     """Test: filters"""
     station = MvgApi.station("Universität, München")


### PR DESCRIPTION
### Solves issues
- #3 
- #4 

### Summary
Nearby searches now support single or multiple returns as `list`, as well as optional argument `transport_types` to filter nearby results by specific types.

### Changes

Adds methods:
- `nearby_multi`
- `nearby_multi_async`

as well as new parameter `transport_types` for existing methods:
- `nearby`
- `nearby_async`

### Tests
Corresponding unittests have been added.