### PR TITLE
Update mvgapi.py - fix lines() calling station_async()

### DIFF
--- a/src/mvg/mvgapi.py
+++ b/src/mvg/mvgapi.py
@@ -201,7 +201,7 @@ class MvgApi:
         :raises MvgApiError: raised on communication failure or unexpected result
         :return: a list of lines as dictionary
         """
-        return asyncio.run(MvgApi.stations_async())
+        return asyncio.run(MvgApi.lines_async())
 
     @staticmethod
     async def station_async(query: str) -> dict[str, str] | None:


### PR DESCRIPTION
Currently the function lines() has a copy&paste erroe, where it calls the function station_async() instead of lines_async(), making the lines() function giving the same output as the stations() function.

With this small change, this should be fixed.