### PR TITLE
feat: allow optional HTTP client sessions for departure requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,21 +105,28 @@ if station:
 
 ## Advanced Usage: Asynchronous Methods
 
-The class `MvgApi` internally calls asynchronous methods using `asyncio` and `aiohttp` to perform the web requests efficiently. These asynchronous methods are marked by the suffix `_async` and can be utilized by users in projects with concurrent code.
+The class `MvgApi` internally calls asynchronous methods using `asyncio` and `aiohttp` to perform web requests efficiently. These asynchronous methods are marked by the suffix `_async` and can be utilized by users in projects with concurrent code.
 
-The basic example but with asynchronous calls looks like this:
+**Session management:**
+
+- Only async methods (ending with `_async`) accept an optional `session` parameter, which must be an `aiohttp.ClientSession`.
+- Synchronous methods do not accept a session parameter and manage their own session internally.
+
+**Example: Using a shared aiohttp session for multiple async calls**
 
 ```python
 import asyncio
+import aiohttp
 from mvg import MvgApi
 
 async def demo() -> None:
-    station = await MvgApi.station_async('Universität, München')
-    if station:
-        departures = MvgApi.departures_async(station['id'])
-        print(station, await departures)
-loop = asyncio.get_event_loop()
-loop.run_until_complete(demo())
+    async with aiohttp.ClientSession() as session:
+        station = await MvgApi.station_async('Universität, München', session=session)
+        if station:
+            departures = await MvgApi.departures_async(station['id'], session=session)
+            print(station, departures)
+
+asyncio.run(demo())
 ```
 
 ### Note about notebooks and running event loops
@@ -130,3 +137,7 @@ notebooks), Python's `asyncio.run()` would normally raise RuntimeError. This
 library detects that case and transparently submits the underlying coroutine
 to a background event loop so the synchronous convenience methods continue to
 work from notebooks and similar environments.
+
+## Notable Contributions
+
+- Thanks to [jrester](https://github.com/jrester) for adding support of reusable aiohttp HTTP sessions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name    = "mvg"
-version = "1.4.0"
+version = "1.5.0"
 
 description = "An unofficial interface to timetable information of the Münchner Verkehrsgesellschaft (MVG)."
 readme      = "README.md"

--- a/src/mvg/mvgapi.py
+++ b/src/mvg/mvgapi.py
@@ -158,14 +158,17 @@ class MvgApi:
             return await MvgApi.__get(url, tmp_session)
 
     @staticmethod
-    async def station_ids_async() -> list[str]:
+    async def station_ids_async(
+        session: aiohttp.ClientSession | None = None,
+    ) -> list[str]:
         """Retrieve a list of all valid station ids.
 
+        :param session: optional client sesion. If None is given, a temporary session is created
         :raises MvgApiError: raised on communication failure or unexpected result
         :return: station ids as a list
         """
         try:
-            result = await MvgApi.__api(Base.ZDM, Endpoint.ZDM_STATION_IDS)
+            result = await MvgApi.__api(Base.ZDM, Endpoint.ZDM_STATION_IDS, session=session)
             if not isinstance(result, list):
                 msg = f"Bad API call: Expected a list, but got {type(result)}."
                 raise MvgApiError(msg)
@@ -175,14 +178,17 @@ class MvgApi:
             raise MvgApiError(msg) from exc
 
     @staticmethod
-    async def stations_async() -> list[dict[str, Any]]:
+    async def stations_async(
+        session: aiohttp.ClientSession | None = None,
+    ) -> list[dict[str, Any]]:
         """Retrieve a list of all stations.
 
+        :param session: optional client sesion. If None is given, a temporary session is created
         :raises MvgApiError: raised on communication failure or unexpected result
         :return: a list of stations as dictionary
         """
         try:
-            result = await MvgApi.__api(Base.ZDM, Endpoint.ZDM_STATIONS)
+            result = await MvgApi.__api(Base.ZDM, Endpoint.ZDM_STATIONS, session=session)
             if not isinstance(result, list):
                 msg = f"Bad API call: Expected a list, but got {type(result)}."
                 raise MvgApiError(msg)
@@ -202,14 +208,17 @@ class MvgApi:
         return MvgApi._run(MvgApi.stations_async())
 
     @staticmethod
-    async def lines_async() -> list[dict[str, Any]]:
+    async def lines_async(
+        session: aiohttp.ClientSession | None = None,
+    ) -> list[dict[str, Any]]:
         """Retrieve a list of all lines.
 
+        :param session: optional client sesion. If None is given, a temporary session is created
         :raises MvgApiError: raised on communication failure or unexpected result
         :return: a list of lines as dictionary
         """
         try:
-            result = await MvgApi.__api(Base.ZDM, Endpoint.ZDM_LINES)
+            result = await MvgApi.__api(Base.ZDM, Endpoint.ZDM_LINES, session=session)
             if not isinstance(result, list):
                 msg = f"Bad API call: Expected a list, but got {type(result)}."
                 raise MvgApiError(msg)
@@ -229,10 +238,14 @@ class MvgApi:
         return MvgApi._run(MvgApi.lines_async())
 
     @staticmethod
-    async def station_async(query: str) -> dict[str, str] | None:
+    async def station_async(
+        query: str,
+        session: aiohttp.ClientSession | None = None,
+    ) -> dict[str, str] | None:
         """Find a station by station name and place or global station id.
 
         :param query: name, place ('Universität, München') or global station id (e.g. 'de:09162:70')
+        :param session: optional client sesion. If None is given, a temporary session is created
         :raises MvgApiError: raised on communication failure or unexpected result
         :return: the first matching station as dictionary with keys 'id', 'name', 'place', 'latitude', 'longitude'
 
@@ -252,7 +265,7 @@ class MvgApi:
             if MvgApi.valid_station_id(query):
                 stations_endpoint = Endpoint.ZDM_STATIONS.value[0]
                 station_endpoint = f"{stations_endpoint}/{query}"
-                result = await MvgApi.__api(Base.ZDM, (station_endpoint, []))
+                result = await MvgApi.__api(Base.ZDM, (station_endpoint, []), session=session)
                 if not isinstance(result, dict):
                     msg = f"Bad API call: Expected a dict, but got {type(result)}."
                     raise MvgApiError(msg)
@@ -268,7 +281,7 @@ class MvgApi:
             # use open search if query is not a station id
             args = dict.fromkeys(Endpoint.FIB_LOCATION.value[1])
             args.update({"query": query.strip(), "locationTypes": "STATION"})
-            result = await MvgApi.__api(Base.FIB, Endpoint.FIB_LOCATION, args)
+            result = await MvgApi.__api(Base.FIB, Endpoint.FIB_LOCATION, args, session=session)
             if not isinstance(result, list):
                 msg = f"Bad API call: Expected a list, but got {type(result)}."
                 raise MvgApiError(msg)
@@ -315,12 +328,14 @@ class MvgApi:
         latitude: float,
         longitude: float,
         full_list: bool = True,
+        session: aiohttp.ClientSession | None = None,
     ) -> dict[str, str] | list[dict[str, str]] | None:
         """Find the nearest station by coordinates.
 
         :param latitude: coordinate in decimal degrees
         :param longitude: coordinate in decimal degrees
         :param full_list: return full list of stations instead of a single location
+        :param session: optional client sesion. If None is given, a temporary session is created
         :raises MvgApiError: raised on communication failure or unexpected result
         :return: the fist matching station as dictionary with keys 'id', 'name', 'place', 'latitude', 'longitude'
             or a list of such station dictionaries, if requested by `full_list` argument
@@ -332,7 +347,7 @@ class MvgApi:
         try:
             args = dict.fromkeys(Endpoint.FIB_NEARBY.value[1])
             args.update({"latitude": latitude, "longitude": longitude})
-            result = await MvgApi.__api(Base.FIB, Endpoint.FIB_NEARBY, args)
+            result = await MvgApi.__api(Base.FIB, Endpoint.FIB_NEARBY, args, session=session)
             if not isinstance(result, list):
                 msg = f"Bad API call: Expected a list, but got {type(result)}."
                 raise MvgApiError(msg)
@@ -425,7 +440,7 @@ class MvgApi:
             if transport_types is None:
                 transport_types = TransportType.all()
             args.update({"transportTypes": ",".join([product.name for product in transport_types])})
-            result = await MvgApi.__api(Base.FIB, Endpoint.FIB_DEPARTURE, args, session)
+            result = await MvgApi.__api(Base.FIB, Endpoint.FIB_DEPARTURE, args, session=session)
             if not isinstance(result, list):
                 msg = f"Bad API call: Expected a list, but got {type(result)}."
                 raise MvgApiError(msg)
@@ -455,14 +470,12 @@ class MvgApi:
         limit: int = MVGAPI_DEFAULT_LIMIT,
         offset: int = 0,
         transport_types: list[TransportType] | None = None,
-        session: aiohttp.ClientSession | None = None,
     ) -> list[dict[str, Any]]:
         """Retrieve the next departures.
 
         :param limit: limit of departures, defaults to 10
         :param offset: offset (e.g. walking distance to the station) in minutes, defaults to 0
         :param transport_types: filter by transport type, defaults to None
-        :param session: optional client sesion. If None is given, a temporary session is created
         :raises MvgApiError: raised on communication failure or unexpected result
         :return: a list of departures as dictionary
 
@@ -483,7 +496,7 @@ class MvgApi:
             ]
 
         """
-        return MvgApi._run(self.departures_async(self.station_id, limit, offset, transport_types, session))
+        return MvgApi._run(self.departures_async(self.station_id, limit, offset, transport_types))
 
     # Single background loop/thread used when a running loop exists in this
     # thread (e.g. Jupyter). Created lazily on first use.

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -1,5 +1,6 @@
 """Demonstration tests (see README.md)."""
 
+import aiohttp
 import pytest
 
 from mvg import MvgApi, TransportType
@@ -78,6 +79,18 @@ async def test_async() -> None:
         departures = await MvgApi.departures_async(station["id"])
         assert len(departures) > 0
         print("ASYNC: ", station, departures, end="\n\n")
+
+
+@pytest.mark.asyncio
+async def test_test_async_with_shared_session() -> None:
+    """Test: usage with shared aiohttp session."""
+    async with aiohttp.ClientSession() as session:
+        station = await MvgApi.station_async("Universität, München", session=session)
+        assert station["id"] == "de:09162:70"
+        if station:
+            departures = await MvgApi.departures_async(station["id"], session=session)
+            assert len(departures) > 0
+            print("ASYNC: ", station, departures, end="\n\n")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
I am currently working on an improved [MVG integration for Home-Assistant](https://github.com/jrester/home-assistant-mvg). To reduce the number of open sessions, [Home-Assistant encourages the reuse of client sessions](https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/inject-websession/).

This PR enable the optional use of reusable sessions for the `departures` endpoints, to reduce the number of open sessions during polling the MVG API. 