### PR TITLE
feat: add `delay`, `platform` and `realtime` info to departures

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ if station:
 [{
 'time': 1668524580,
 'planned': 1668524460,
+'delay': 0,
+'platform': 1,
+'realtime': True,
 'line': 'U3',
 'destination': 'Fürstenried West',
 'type': 'U-Bahn',

--- a/src/mvg/mvgapi.py
+++ b/src/mvg/mvgapi.py
@@ -419,6 +419,9 @@ class MvgApi:
                 {
                     "time": 1668524580,
                     "planned": 1668524460,
+                    "delay": 0,
+                    "platform": 1,
+                    "realtime": True,
                     "line": "U3",
                     "destination": "Fürstenried West",
                     "type": "U-Bahn",
@@ -449,6 +452,9 @@ class MvgApi:
                 {
                     "time": int(departure["realtimeDepartureTime"] / 1000),
                     "planned": int(departure["plannedDepartureTime"] / 1000),
+                    "delay": departure.get("delayInMinutes"),
+                    "platform": departure.get("platform"),
+                    "realtime": departure["realtime"],
                     "line": departure["label"],
                     "destination": departure["destination"],
                     "type": TransportType[departure["transportType"]].value[0],
@@ -485,6 +491,9 @@ class MvgApi:
                 {
                     "time": 1668524580,
                     "planned": 1668524460,
+                    "delay": 0,
+                    "platform": 1,
+                    "realtime": True,
                     "line": "U3",
                     "destination": "Fürstenried West",
                     "type": "U-Bahn",


### PR DESCRIPTION
The MVG provides some additional information for each departure. While `realtime` seems to be always provided, `delay` is only available if `realtime` is `True` and might otherwise be omitted. 
Additionally, `platform` is present only for some transport types. In my testing this is `U-Bahn` and `S-Bahn`, but not for `Bus` and `Tram`.