### PR TITLE
feat: use `dataclass` instead of plain `dict` for responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ from mvg import MvgApi
 
 station = MvgApi.station('Universität, München')
 if station:
-    mvgapi = MvgApi(station['id'])
+    mvgapi = MvgApi(station.id)
     departures = mvgapi.departures()
     print(station, departures)
 ```
@@ -69,7 +69,7 @@ from mvg import MvgApi, TransportType
 
 station = MvgApi.station('Universität, München')
 if station:
-    mvgapi = MvgApi(station['id'])
+    mvgapi = MvgApi(station.id)
     departures = mvgapi.departures(
         limit=3,
         offset=5,
@@ -79,31 +79,47 @@ if station:
 
 ### Example results
 
-`station()` or `nearby()` results a `dict`:
+`station()` or `nearby()` results a `MvgStationInfo`:
 ```
-{ 
-'id': 'de:09162:70', 
-'name': 'Universität', 
-'place': 'München'
-'latitude': 48.15007, 
-'longitude': 11.581
+MvgStationInfo(
+    id='de:09162:70',
+    name='Universität',
+    place='München',
+    latitude=48.149515,
+    longitude=11.58082
+)
+```
+`departures()` results a `list` of `MvgDepartureInfo`:
+```
+[
+    MvgDepartureInfo(
+        time=1759587672,
+        planned=1759587120,
+        delay=9,
+        line="U4",
+        platform=2,
+        realtime=True,
+        destination="Arabellapark",
+        type="U-Bahn",
+        icon="mdi:subway",
+        cancelled=False,
+        messages=[],
+    ),
+    ...,
+]
+```
+`lines()` returns a `set` of `MvgLineInfo`:
+```
+{
+    MvgLineInfo(
+        label="S5",
+        type="S-Bahn",
+        icon="mdi:subway-variant",
+        sev=False,
+        diva_id="92M05"
+    ),
+    ...,
 }
-```
-`departures()` results a `list` of `dict`:
-```
-[{
-'time': 1668524580,
-'planned': 1668524460,
-'delay': 0,
-'platform': 1,
-'realtime': True,
-'line': 'U3',
-'destination': 'Fürstenried West',
-'type': 'U-Bahn',
-'icon': 'mdi:subway',
-'cancelled': False,
-'messages': []
-}, ... ]
 ```
 
 ## Advanced Usage: Asynchronous Methods
@@ -126,7 +142,7 @@ async def demo() -> None:
     async with aiohttp.ClientSession() as session:
         station = await MvgApi.station_async('Universität, München', session=session)
         if station:
-            departures = await MvgApi.departures_async(station['id'], session=session)
+            departures = await MvgApi.departures_async(station.id, session=session)
             print(station, departures)
 
 asyncio.run(demo())

--- a/src/mvg/__init__.py
+++ b/src/mvg/__init__.py
@@ -1,5 +1,5 @@
 """An unofficial interface to timetable information of the Münchner Verkehrsgesellschaft (MVG)."""
 
-from .mvgapi import MvgApi, MvgApiError, TransportType
+from .mvgapi import MvgApi, MvgApiError, MvgDepartureInfo, MvgLineInfo, MvgStationInfo, TransportType
 
-__all__ = ["MvgApi", "MvgApiError", "TransportType"]
+__all__ = ["MvgApi", "MvgApiError", "MvgDepartureInfo", "MvgLineInfo", "MvgStationInfo", "TransportType"]

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -3,15 +3,16 @@
 import aiohttp
 import pytest
 
-from mvg import MvgApi, TransportType
+from mvg import MvgApi, MvgStationInfo, TransportType
 
 
 def test_basic() -> None:
     """Test: basic usage."""
     station = MvgApi.station("Universität, München")
-    assert station["id"] == "de:09162:70"
+    assert station is not None
+    assert station.id == "de:09162:70"
     if station:
-        mvgapi = MvgApi(station["id"])
+        mvgapi = MvgApi(station.id)
         departures = mvgapi.departures()
         assert len(departures) > 0
         print("BASIC: ", station, departures, end="\n\n")
@@ -20,9 +21,10 @@ def test_basic() -> None:
 def test_faraway() -> None:
     """Test: usage with distant station."""
     station = MvgApi.station("Ebersberg, Ebersberg (Obb.)")
-    assert station["id"] == "de:09175:4070"
+    assert station is not None
+    assert station.id == "de:09175:4070"
     if station:
-        mvgapi = MvgApi(station["id"])
+        mvgapi = MvgApi(station.id)
         departures = mvgapi.departures()
         assert len(departures) > 0
         print("BASIC: ", station, departures, end="\n\n")
@@ -31,9 +33,10 @@ def test_faraway() -> None:
 def test_village() -> None:
     """Test: usage with village station."""
     station = MvgApi.station("Egmating, Schule")
-    assert station["id"] == "de:09175:4212"
+    assert station is not None
+    assert station.id == "de:09175:4212"
     if station:
-        mvgapi = MvgApi(station["id"])
+        mvgapi = MvgApi(station.id)
         departures = mvgapi.departures()
         assert len(departures) > 0
         print("BASIC: ", station, departures, end="\n\n")
@@ -42,7 +45,9 @@ def test_village() -> None:
 def test_nearby() -> None:
     """Test: station by coordinates."""
     station = MvgApi.nearby(48.1, 11.5)
-    assert station["id"] == "de:09162:1480"
+    assert station is not None
+    assert isinstance(station, MvgStationInfo)
+    assert station.id == "de:09162:1480"
     print("NEARBY: ", station, end="\n\n")
 
 
@@ -51,16 +56,17 @@ def test_nearby_list() -> None:
     stations = MvgApi.nearby(48.1, 11.5, True)
     assert isinstance(stations, list)
     assert len(stations) > 0
-    assert stations[0]["id"] == "de:09162:1480"
+    assert stations[0].id == "de:09162:1480"
     print("NEARBY: ", stations, end="\n\n")
 
 
 def test_filter() -> None:
     """Test: filters."""
     station = MvgApi.station("Universität, München")
-    assert station["id"] == "de:09162:70"
+    assert station is not None
+    assert station.id == "de:09162:70"
     if station:
-        mvgapi = MvgApi(station["id"])
+        mvgapi = MvgApi(station.id)
         departures = mvgapi.departures(
             limit=3,
             offset=5,
@@ -92,9 +98,10 @@ def test_lines_station() -> None:
 async def test_async() -> None:
     """Test: advanced usage with asynchronous methods."""
     station = await MvgApi.station_async("Universität, München")
-    assert station["id"] == "de:09162:70"
+    assert station is not None
+    assert station.id == "de:09162:70"
     if station:
-        departures = await MvgApi.departures_async(station["id"])
+        departures = await MvgApi.departures_async(station.id)
         assert len(departures) > 0
         print("ASYNC: ", station, departures, end="\n\n")
 
@@ -104,9 +111,10 @@ async def test_test_async_with_shared_session() -> None:
     """Test: usage with shared aiohttp session."""
     async with aiohttp.ClientSession() as session:
         station = await MvgApi.station_async("Universität, München", session=session)
-        assert station["id"] == "de:09162:70"
+        assert station is not None
+        assert station.id == "de:09162:70"
         if station:
-            departures = await MvgApi.departures_async(station["id"], session=session)
+            departures = await MvgApi.departures_async(station.id, session=session)
             assert len(departures) > 0
             print("ASYNC: ", station, departures, end="\n\n")
 
@@ -121,4 +129,4 @@ async def test_station_sync_in_running_loop_real_query() -> None:
     """
     station = MvgApi.station("Universität, München")
     assert station is not None
-    assert station["id"] == "de:09162:70"
+    assert station.id == "de:09162:70"


### PR DESCRIPTION
This is a proposal to change the responses of all API calls to use `dataclass` instead of plain `dict`. In my opinion this makes it easier to work with the API in third party applications and libraries since the responses are now typed. Additionally, it enables the relative accessors for departure time and makes it easier to de-duplicate response objects (e.g., lines), because `dict` is not hashable but a frozen `dataclass` is. 

For backwards compatibility I kept the `dict` style key access for all response objects. This means that `station["id"]` is still valid and existing code should not break completely.

This is already based on https://github.com/mondbaron/mvg/pull/15, but I wanted to split this into a separate MR since this is a quite significant change. It also includes the changes from https://github.com/mondbaron/mvg/pull/16.

What do you think about the proposal?